### PR TITLE
Refactor definition and response generator to properly handle slice, map and interface types

### DIFF
--- a/components/endpoint/endpoints.go
+++ b/components/endpoint/endpoints.go
@@ -3,10 +3,12 @@ package endpoint
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/go-swagno/swagno/components/mime"
 	"github.com/go-swagno/swagno/components/parameter"
 	"github.com/go-swagno/swagno/http/response"
+	"github.com/go-swagno/swagno/utils"
 )
 
 // MethodType represents HTTP request methods.
@@ -110,8 +112,9 @@ func (e *EndPoint) GetPath() string {
 // GetBodyJsonParameter makes the body definitions and parameter for body if present. Parameters for body are described via schema
 // definition so that's why it doesn't use the 'Parameter' object like the other ones.
 func (e *EndPoint) GetBodyJsonParameter() *parameter.JsonParameter {
+	hash := utils.GenerateHash(utils.ConvertToString(e.Body))
 	if e.Body != nil {
-		bodyRef := fmt.Sprintf("#/definitions/%T", e.Body)
+		bodyRef := fmt.Sprintf("#/definitions/%T_%s", e.Body, hash)
 		bodySchema := parameter.JsonResponseSchema{
 			Ref: bodyRef,
 		}
@@ -120,7 +123,7 @@ func (e *EndPoint) GetBodyJsonParameter() *parameter.JsonParameter {
 			bodySchema = parameter.JsonResponseSchema{
 				Type: "array",
 				Items: &parameter.JsonResponseSchemeItems{
-					Ref: fmt.Sprintf("#/definitions/%T", e.Body),
+					Ref: strings.ReplaceAll(fmt.Sprintf("#/definitions/%T_%s", e.Body, hash), "[]", ""),
 				},
 			}
 		}

--- a/components/parameter/parameter.go
+++ b/components/parameter/parameter.go
@@ -79,8 +79,9 @@ type JsonResponseSchema struct {
 }
 
 type JsonResponseSchemeItems struct {
-	Type string `json:"type,omitempty"`
-	Ref  string `json:"$ref,omitempty"`
+	Type  string                   `json:"type,omitempty"`
+	Ref   string                   `json:"$ref,omitempty"`
+	Items *JsonResponseSchemeItems `json:"items,omitempty"`
 }
 
 // Parameter represents a parameter in an API endpoint.

--- a/example/fiber/server.go
+++ b/example/fiber/server.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-swagno/swagno-fiber/swagger"
 	"github.com/go-swagno/swagno/components/endpoint"
 	"github.com/go-swagno/swagno/components/mime"
-	"github.com/go-swagno/swagno/components/parameter"
 	"github.com/go-swagno/swagno/example/models"
 	"github.com/go-swagno/swagno/http/response"
 	"github.com/gofiber/fiber/v2"
@@ -22,43 +21,34 @@ func main() {
 			endpoint.WithMethod(endpoint.GET),
 			endpoint.WithPath("/product"),
 			endpoint.WithTags("product"),
-			endpoint.WithSuccessfulReturns([]response.Info{response.New([]models.Product{}, "200", "Product List")}),
+			endpoint.WithSuccessfulReturns([]response.Info{
+				response.New("string", "200", "Product List"),                                                        // OK
+				response.New(models.StructResponse1{}, "201", "Product List"),                                        // OK
+				response.New(models.StructResponse1{InterfaceType: "string"}, "202", "Product List"),                 // OK
+				response.New(models.StructResponse1{InterfaceType: models.StructResponse2{}}, "203", "Product List"), // OK
+				response.New([]int{}, "204", "Product List"),                                                         // OK
+				response.New([]*int{}, "205", "Product List"),                                                        // OK
+				response.New([][]int{}, "206", "Product List"),                                                       // OK
+				response.New([]models.StructResponse1{}, "207", "Product List"),                                      // OK
+				response.New([]*models.StructResponse1{}, "208", "Product List"),                                     // OK
+				response.New([]map[string]string{}, "209", "Product List"),                                           // OK
+				response.New([]interface{}{}, "210", "Product List"),                                                 // OK
+				response.New([]interface{}{models.StructResponse1{}}, "211", "Product List"),                         // not desired result
+				response.New([][]models.StructResponse1{}, "212", "Product List"),                                    // OK
+				response.New([][]*models.StructResponse1{}, "213", "Product List"),                                   // OK
+				response.New(map[string]int{"field": 123}, "214", "Product List"),                                    // OK
+				response.New(map[string]*int{}, "215", "Product List"),                                               // OK
+				response.New(map[string]models.StructResponse1{}, "216", "Product List"),                             // OK
+				response.New(map[string]*models.StructResponse1{}, "217", "Product List"),                            // OK
+				response.New(map[string][]models.StructResponse1{}, "218", "Product List"),                           // OK
+				response.New(map[string][]*models.StructResponse1{}, "219", "Product List"),                          // OK
+				response.New(map[string]interface{}{}, "220", "Product List"),                                        // OK
+				response.New(map[string]interface{}{"field": 123}, "221", "Product List"),                            // OK
+			}),
 			endpoint.WithDescription(desc),
 			endpoint.WithProduce([]mime.MIME{mime.JSON, mime.XML}),
 			endpoint.WithConsume([]mime.MIME{mime.JSON}),
 			endpoint.WithSummary("this is a test summary"),
-		),
-		endpoint.New(
-			endpoint.WithMethod(endpoint.GET),
-			endpoint.WithPath("/product/{id}"),
-			endpoint.WithTags("product"),
-			endpoint.WithParams(parameter.IntParam("id", parameter.WithIn(parameter.Path), parameter.WithRequired())),
-			endpoint.WithSuccessfulReturns([]response.Info{models.SuccessfulResponse{}}),
-			endpoint.WithErrors([]response.Info{models.UnsuccessfulResponse{}}),
-			endpoint.WithProduce([]mime.MIME{mime.JSON, mime.XML}),
-		),
-		endpoint.New(
-			endpoint.WithMethod(endpoint.GET),
-			endpoint.WithPath("/product/{id}/detail"),
-			endpoint.WithTags("product"),
-			endpoint.WithParams(parameter.IntParam("id", parameter.WithIn(parameter.Path), parameter.WithRequired())),
-			endpoint.WithSuccessfulReturns([]response.Info{response.New(models.MapTest{
-				"data": models.Product{},
-			}, "200", "")}),
-			endpoint.WithErrors([]response.Info{response.New(map[string]interface{}{
-				"error":     "Not Authorized",
-				"errorCode": 401,
-			}, "401", "Not Authorized")}),
-			endpoint.WithProduce([]mime.MIME{mime.JSON, mime.XML}),
-		),
-		endpoint.New(
-			endpoint.WithMethod(endpoint.POST),
-			endpoint.WithPath("/product"),
-			endpoint.WithTags("product"),
-			endpoint.WithBody(models.ProductPost{}),
-			endpoint.WithSuccessfulReturns([]response.Info{response.New(models.Product{}, "201", "Created Product")}),
-			endpoint.WithErrors([]response.Info{response.New([]models.ErrorResponse{}, "400", "")}),
-			endpoint.WithProduce([]mime.MIME{mime.JSON, mime.XML}),
 		),
 	}
 

--- a/example/models/types.go
+++ b/example/models/types.go
@@ -1,0 +1,20 @@
+package models
+
+// primitive types as response
+type Integer int
+
+// struct as response
+type StructResponse1 struct {
+	PrimitiveType int                        `json:"primitive_type"`
+	SliceType     []int                      `json:"slice_type"`
+	MapType       map[string]string          `json:"map_type_string_string"`
+	MapType2      map[string]StructResponse2 `json:"map_type_string_struct"`
+	// MapType2      map[string]StructResponse1 `json:"map_type_string_struct"` recursive
+	PointerType   *int        `json:"pointer_type_int"`
+	PointerType2  *Integer    `json:"pointer_type_int_response"`
+	InterfaceType interface{} `json:"interface_type"`
+}
+
+type StructResponse2 struct {
+	PrimitiveType int `json:"primitive_type"`
+}

--- a/generate.go
+++ b/generate.go
@@ -119,5 +119,5 @@ func (s *Swagger) createDefinitions(r []response.Info) {
 
 func (s *Swagger) createDefinition(t interface{}) {
 	generator := generator.NewDefinitionGenerator((*s).Definitions)
-	generator.CreateDefinition(t)
+	generator.CreateDefinition(t, "")
 }

--- a/generator/response.go
+++ b/generator/response.go
@@ -17,17 +17,66 @@ func NewResponseGenerator() *ResponseGenerator {
 }
 
 func (g ResponseGenerator) GenerateJsonResponseScheme(model any) *parameter.JsonResponseSchema {
+	hash := utils.GenerateHash(utils.ConvertToString(model))
+
 	switch reflect.TypeOf(model).Kind() {
 	case reflect.Slice:
-		sliceElementKind := reflect.TypeOf(model).Elem().Kind()
-		if sliceElementKind == reflect.Struct {
+		sliceElement := reflect.TypeOf(model).Elem()
+		if sliceElement.Kind() == reflect.Pointer {
+			sliceElement = sliceElement.Elem()
+		}
+
+		sliceElementKind := sliceElement.Kind()
+		switch sliceElementKind {
+		case reflect.Struct:
 			return &parameter.JsonResponseSchema{
 				Type: "array",
 				Items: &parameter.JsonResponseSchemeItems{
-					Ref: strings.ReplaceAll(fmt.Sprintf("#/definitions/%s", reflect.TypeOf(model).Elem().String()), "[]", ""),
+					Ref: strings.ReplaceAll(fmt.Sprintf("#/definitions/%s_%s", reflect.TypeOf(model).Elem().String(), hash), "[]", ""),
 				},
 			}
-		} else {
+
+		case reflect.Slice:
+			// TODO: make this recursive, now support only [][]type
+			innerElement := reflect.New(sliceElement.Elem()).Elem()
+			if innerElement.Kind() == reflect.Pointer {
+				innerElement = reflect.New(sliceElement.Elem().Elem()).Elem()
+			}
+
+			innerElementScheme := g.GenerateJsonResponseScheme(innerElement.Interface())
+			items := &parameter.JsonResponseSchemeItems{}
+
+			if innerElementScheme.Type != "" {
+				items.Type = innerElementScheme.Type
+			} else {
+				items.Ref = strings.ReplaceAll(fmt.Sprintf("#/definitions/%s_%s", sliceElement.Elem().String(), hash), "[]", "")
+			}
+
+			return &parameter.JsonResponseSchema{
+				Type: "array",
+				Items: &parameter.JsonResponseSchemeItems{
+					Type:  "array",
+					Items: items,
+				},
+			}
+
+		case reflect.Map:
+			return &parameter.JsonResponseSchema{
+				Type: "array",
+				Items: &parameter.JsonResponseSchemeItems{
+					Ref: strings.ReplaceAll(fmt.Sprintf("#/definitions/%s_%s", sliceElement.String(), hash), "[]", ""),
+				},
+			}
+
+		case reflect.Interface:
+			return &parameter.JsonResponseSchema{
+				Type: "array",
+				Items: &parameter.JsonResponseSchemeItems{
+					Type: "object", // TODO: get real type of interface
+				},
+			}
+
+		default:
 			return &parameter.JsonResponseSchema{
 				Type: "array",
 				Items: &parameter.JsonResponseSchemeItems{
@@ -37,10 +86,10 @@ func (g ResponseGenerator) GenerateJsonResponseScheme(model any) *parameter.Json
 		}
 
 	case reflect.Map:
-		ref := strings.ReplaceAll(fmt.Sprintf("#/definitions/%T", model), "[]", "")
+		ref := strings.ReplaceAll(fmt.Sprintf("#/definitions/%T_%s", model, hash), "[]", "")
 		// preventing override map definitions, generate random name for map if its not typed
 		if reflect.TypeOf(model).Name() == "" {
-			ref = strings.ReplaceAll(fmt.Sprintf("#/definitions/%T_%s", model, utils.GetHashOfMap(utils.ConvertInterfaceToMap(model))), "[]", "")
+			ref = strings.ReplaceAll(fmt.Sprintf("#/definitions/%T_%s_%s", model, utils.GetHashOfMap(utils.ConvertInterfaceToMap(model)), hash), "[]", "")
 		}
 		return &parameter.JsonResponseSchema{
 			Ref: ref,
@@ -49,12 +98,14 @@ func (g ResponseGenerator) GenerateJsonResponseScheme(model any) *parameter.Json
 	default:
 		if g.hasStructFields(model) {
 			return &parameter.JsonResponseSchema{
-				Ref: strings.ReplaceAll(fmt.Sprintf("#/definitions/%T", model), "[]", ""),
+				Ref: strings.ReplaceAll(fmt.Sprintf("#/definitions/%T_%s", model, hash), "[]", ""),
 			}
 		}
 	}
 
-	return nil
+	return &parameter.JsonResponseSchema{
+		Type: getType(reflect.TypeOf(model).String()),
+	}
 }
 
 func (g ResponseGenerator) hasStructFields(s interface{}) bool {

--- a/utils/hash.go
+++ b/utils/hash.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/sha256"
 	"fmt"
+	"hash/fnv"
 	"reflect"
 	"sort"
 )
@@ -17,6 +18,16 @@ func ConvertInterfaceToMap(t interface{}) map[string]interface{} {
 	}
 
 	return m
+}
+
+func ConvertToString(t interface{}) string {
+	return fmt.Sprintf("%T_%+[1]v", t)
+}
+
+func GenerateHash(s string) string {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return fmt.Sprint(h.Sum32())
 }
 
 func GetHashOfMap(m map[string]interface{}) string {


### PR DESCRIPTION
I open PR to my old PR to show only additions to support all types including interfaces.

I have been burn out while doing this because there are many cases and it got more complicated 😄 Fixing something brokes another thing etc. And I am tired 😮‍💨

I think I achieved to support many types that you can see in [example/fiber/server.go](https://github.com/domhoward14/swagno/pull/5/files#diff-c74bf7bbf69e9b1bcad39e835df0536772b01217b2652250e043d10f9cdd8e1d)

But it came with complexity ofc. I think it should be refactored later.

I added hashes after each model which generated from its value. This provides overriding types expecially maps and interfaces. 

Btw, I will review my code and refactor necessary parts later in my free time. Can you point the parts which are complex when you review?
